### PR TITLE
feat(AG-3630): support cloud scheduler in single region

### DIFF
--- a/modules/main/main.tf
+++ b/modules/main/main.tf
@@ -242,9 +242,12 @@ resource "google_cloud_run_v2_job" "scaler_function" {
 }
 
 # Scheduler for running the scaler function
+# This will be deployed in ONE region only. By default it will be in us-central1 unless overridden by the user.
+# Multiple scheduler jobs in the same region will be created if multiple scanners are deployed in the same region.
+# Each scheduler job can have a single HTTP target, so we create a separate job for each scanner.
 resource "google_cloud_scheduler_job" "scaler_scheduler_job" {
   name     = "upwind-scaler-scheduler-job-${var.scanner_id}"
-  region   = var.region
+  region   = var.scheduler_region != "" ? var.scheduler_region : var.default_scheduler_region
   schedule = var.scaler_function_schedule
 
 

--- a/modules/main/variables.tf
+++ b/modules/main/variables.tf
@@ -118,6 +118,48 @@ variable "availability_zones" {
   }
 }
 
+### Scheduler related
+locals {
+  # Supported Scheduler regions, see https://cloud.google.com/scheduler/docs/locations
+  valid_scheduler_regions = [
+    # Americas
+    "northamerica-northeast1", "southamerica-east1",
+    "us-central1", "us-east1", "us-east4", "us-west1", "us-west2", "us-west3", "us-west4",
+
+    # Europe
+    "europe-central2", "europe-west1", "europe-west2", "europe-west3", "europe-west6",
+
+    # Asia Pacific
+    "asia-east1", "asia-east2", "asia-northeast1", "asia-northeast2", "asia-northeast3",
+    "asia-south1", "asia-southeast1", "asia-southeast2",
+
+    # Australia
+    "australia-southeast1"
+  ]
+}
+
+variable "default_scheduler_region" {
+  type        = string
+  description = "The default region to use for the Cloud Scheduler job if no specific region is provided."
+  default     = "us-central1"
+
+  validation {
+    condition     = contains(local.valid_scheduler_regions, var.default_scheduler_region)
+    error_message = "The default scheduler region must be a valid Cloud Scheduler region. Supported regions: ${join(", ", local.valid_scheduler_regions)}."
+  }
+}
+
+variable "scheduler_region" {
+  type        = string
+  description = "The region to use for the Cloud Scheduler job. If not set, the default_scheduler_region will be used."
+  default     = ""
+
+  validation {
+    condition     = var.scheduler_region == "" || contains(local.valid_scheduler_regions, var.scheduler_region)
+    error_message = "The scheduler region must be a valid Cloud Scheduler region. Supported regions: ${join(", ", local.valid_scheduler_regions)}, or leave empty to use default."
+  }
+}
+
 ### Instance Group Related
 
 variable "machine_type" {

--- a/modules/main/versions.tf
+++ b/modules/main/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.23.0, <= 6.35.0"
+      version = ">= 6.23.0, < 8.0.0"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
Tested by deploying scanners to both `us-central1` and `us-east4`. Scheduler runs for both:
<img width="987" height="147" alt="image" src="https://github.com/user-attachments/assets/9bd45963-52c9-4e40-a4e5-4932c32f3b37" />


Validation check:
```
│ Error: Invalid value for variable
│ 
│   on main.tf line 35, in module "gcp_cloudscanner_useast4":
│   35:   scheduler_region = "australia-southeast2"
│     ├────────────────
│     │ local.valid_scheduler_regions is tuple with 23 elements
│     │ var.scheduler_region is "australia-southeast2"
│ 
│ The scheduler region must be a valid Cloud Scheduler region. Supported regions: northamerica-northeast1, southamerica-east1, us-central1, us-east1, us-east4, us-west1, us-west2, us-west3, us-west4, europe-central2, europe-west1, europe-west2, europe-west3, europe-west6,
│ asia-east1, asia-east2, asia-northeast1, asia-northeast2, asia-northeast3, asia-south1, asia-southeast1, asia-southeast2, australia-southeast1, or leave empty to use default.
│ 
│ This was checked by the validation rule at ../../../modules/main/variables.tf:157,3-13.
```

Follow up ticket in https://upwindsecurity.atlassian.net/browse/AG-3709