### PR TITLE
fix(AG-3818): allow regions with more than one number

### DIFF
--- a/modules/main/variables.tf
+++ b/modules/main/variables.tf
@@ -92,7 +92,7 @@ variable "region" {
   default     = "us-central1"
 
   validation {
-    condition     = can(regex("^[a-z]+-[a-z]+[0-9]$", var.region))
+    condition     = can(regex("^[a-z]+-[a-z]+[0-9]+$", var.region))
     error_message = "The region must be a valid Google Cloud region (e.g., us-central1, europe-west4)."
   }
 }
@@ -108,7 +108,7 @@ variable "availability_zones" {
   }
 
   validation {
-    condition     = alltrue([for zone in var.availability_zones : can(regex("^[a-z]+-[a-z]+[0-9]-[a-z]$", zone))])
+    condition     = alltrue([for zone in var.availability_zones : can(regex("^[a-z]+-[a-z]+[0-9]+-[a-z]$", zone))])
     error_message = "All availability zones must be valid Google Cloud zones (e.g., us-central1-a)."
   }
 


### PR DESCRIPTION
found with Ping Identity:
```
│ Error: Invalid value for variable
│ 
│   on main.tf line 76, in module "google_cloudscanner_ucsc-f9202aff68eebe68":
│   76:   region = var.region
│     ├────────────────
│     │ var.region is "europe-west10"
│ 
│ The region must be a valid Google Cloud region (e.g., us-central1,
│ europe-west4).
│ 
│ This was checked by the validation rule at
│ .terraform/modules/google_cloudscanner_ucsc-f9202aff68eebe68/modules/main/variables.tf:94,3-13.
╵
╷
│ Error: Invalid value for variable
│ 
│   on main.tf line 77, in module "google_cloudscanner_ucsc-f9202aff68eebe68":
│   77:   availability_zones = var.availability_zones
│     ├────────────────
│     │ var.availability_zones is list of string with 3 elements
│ 
│ All availability zones must be valid Google Cloud zones (e.g.,
│ us-central1-a).
│ 
│ This was checked by the validation rule at
│ .terraform/modules/google_cloudscanner_ucsc-f9202aff68eebe68/modules/main/variables.tf:110,3-13.
```