### PR TITLE
fix(UP-0): fix for network is already being used error

### DIFF
--- a/modules/main/vpc.tf
+++ b/modules/main/vpc.tf
@@ -75,4 +75,6 @@ resource "google_compute_firewall" "cloudscanner_fw_iap_ssh" {
   # Target specific instances
   target_tags = ["ssh-enabled"]
   priority    = 1000
+
+  depends_on = [google_compute_network.cloudscanner_network]
 }


### PR DESCRIPTION
I've added the explicit depends_on declaration to the firewall resource. This ensures that during terraform destroy, the firewall rule will be destroyed before the network it references, preventing the "network is already being used" error.

The fix is minimal and surgical—just one line added to enforce proper destruction order. Now when you run terraform destroy again, it should complete successfully.

Error Message from `terraform destroy`

`│ Error: Error waiting for Deleting Network: The network resource 'projects/gc-is-gbl-prj-upwind/global/networks/upwind-network-ucsc-8e37f204ce1818a3' is already being used by 'projects/gc-is-gbl-prj-upwind/global/firewalls/upwind-fw-ucsc-8e37f204ce1818a3-iap-ssh'`