### PR TITLE
feat(UP-2441): enable recommended ShieldedVM settings on instance templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
 env:
   TERRAFORM_VERSION: 1.11.0
   TFLINT_VERSION: v0.48.0
-  TRIVY_VERSION: v0.63.0
+  TRIVY_VERSION: v0.71.2
 
 permissions:
   contents: read         # Required for checkout and reading repository content

--- a/modules/main/main.tf
+++ b/modules/main/main.tf
@@ -204,13 +204,14 @@ ENVEOF
     boot         = true
   }
 
-  # Enable Secure Boot to satisfy org policies that mandate it (e.g.
-  # constraints/compute.requireShieldedVm with Secure Boot). vTPM and
-  # integrity monitoring are left at their provider defaults (on), which
-  # they already were for the UEFI_COMPATIBLE default Ubuntu LTS image.
-  # Secure Boot requires that UEFI_COMPATIBLE, signed image.
+  # Shielded VM settings. Required to satisfy the
+  # constraints/compute.requireShieldedVm org policy (and stricter
+  # policies that mandate Secure Boot). The boot image must be
+  # UEFI_COMPATIBLE, which the default Ubuntu LTS image is.
   shielded_instance_config {
-    enable_secure_boot = var.enable_secure_boot
+    enable_secure_boot          = var.enable_secure_boot
+    enable_vtpm                 = true
+    enable_integrity_monitoring = true
   }
 
   network_interface {
@@ -439,13 +440,14 @@ ENVEOF
     boot         = true
   }
 
-  # Enable Secure Boot to satisfy org policies that mandate it (e.g.
-  # constraints/compute.requireShieldedVm with Secure Boot). vTPM and
-  # integrity monitoring are left at their provider defaults (on), which
-  # they already were for the UEFI_COMPATIBLE default Ubuntu LTS image.
-  # Secure Boot requires that UEFI_COMPATIBLE, signed image.
+  # Shielded VM settings. Required to satisfy the
+  # constraints/compute.requireShieldedVm org policy (and stricter
+  # policies that mandate Secure Boot). The boot image must be
+  # UEFI_COMPATIBLE, which the default Ubuntu LTS image is.
   shielded_instance_config {
-    enable_secure_boot = var.enable_secure_boot
+    enable_secure_boot          = var.enable_secure_boot
+    enable_vtpm                 = true
+    enable_integrity_monitoring = true
   }
 
   network_interface {

--- a/modules/main/main.tf
+++ b/modules/main/main.tf
@@ -204,6 +204,16 @@ ENVEOF
     boot         = true
   }
 
+  # Shielded VM settings. Required to satisfy the
+  # constraints/compute.requireShieldedVm org policy (and stricter
+  # policies that mandate Secure Boot). The boot image must be
+  # UEFI_COMPATIBLE, which the default Ubuntu LTS image is.
+  shielded_instance_config {
+    enable_secure_boot          = var.enable_secure_boot
+    enable_vtpm                 = true
+    enable_integrity_monitoring = true
+  }
+
   network_interface {
     network    = local.network
     subnetwork = local.subnet
@@ -428,6 +438,16 @@ ENVEOF
     disk_type    = var.boot_disk_type
     auto_delete  = true
     boot         = true
+  }
+
+  # Shielded VM settings. Required to satisfy the
+  # constraints/compute.requireShieldedVm org policy (and stricter
+  # policies that mandate Secure Boot). The boot image must be
+  # UEFI_COMPATIBLE, which the default Ubuntu LTS image is.
+  shielded_instance_config {
+    enable_secure_boot          = var.enable_secure_boot
+    enable_vtpm                 = true
+    enable_integrity_monitoring = true
   }
 
   network_interface {

--- a/modules/main/main.tf
+++ b/modules/main/main.tf
@@ -204,14 +204,13 @@ ENVEOF
     boot         = true
   }
 
-  # Shielded VM settings. Required to satisfy the
-  # constraints/compute.requireShieldedVm org policy (and stricter
-  # policies that mandate Secure Boot). The boot image must be
-  # UEFI_COMPATIBLE, which the default Ubuntu LTS image is.
+  # Enable Secure Boot to satisfy org policies that mandate it (e.g.
+  # constraints/compute.requireShieldedVm with Secure Boot). vTPM and
+  # integrity monitoring are left at their provider defaults (on), which
+  # they already were for the UEFI_COMPATIBLE default Ubuntu LTS image.
+  # Secure Boot requires that UEFI_COMPATIBLE, signed image.
   shielded_instance_config {
-    enable_secure_boot          = var.enable_secure_boot
-    enable_vtpm                 = true
-    enable_integrity_monitoring = true
+    enable_secure_boot = var.enable_secure_boot
   }
 
   network_interface {
@@ -440,14 +439,13 @@ ENVEOF
     boot         = true
   }
 
-  # Shielded VM settings. Required to satisfy the
-  # constraints/compute.requireShieldedVm org policy (and stricter
-  # policies that mandate Secure Boot). The boot image must be
-  # UEFI_COMPATIBLE, which the default Ubuntu LTS image is.
+  # Enable Secure Boot to satisfy org policies that mandate it (e.g.
+  # constraints/compute.requireShieldedVm with Secure Boot). vTPM and
+  # integrity monitoring are left at their provider defaults (on), which
+  # they already were for the UEFI_COMPATIBLE default Ubuntu LTS image.
+  # Secure Boot requires that UEFI_COMPATIBLE, signed image.
   shielded_instance_config {
-    enable_secure_boot          = var.enable_secure_boot
-    enable_vtpm                 = true
-    enable_integrity_monitoring = true
+    enable_secure_boot = var.enable_secure_boot
   }
 
   network_interface {

--- a/modules/main/variables.tf
+++ b/modules/main/variables.tf
@@ -173,6 +173,12 @@ variable "boot_image" {
   default     = "ubuntu-os-cloud/ubuntu-2404-lts-amd64"
 }
 
+variable "enable_secure_boot" {
+  type        = bool
+  description = "Enable Secure Boot on scanner instances. Requires a UEFI_COMPATIBLE, signed boot image (the default Ubuntu LTS image qualifies). vTPM and integrity monitoring are always enabled."
+  default     = true
+}
+
 variable "boot_disk_size_gb" {
   type        = number
   description = "The disk size in GB to use."


### PR DESCRIPTION
## Problem

HarborFreight had no scanners spinning up: the MIG could not create instances because both instance templates ([UP-2441](https://upwindsecurity.atlassian.net/browse/UP-2441)) lacked a `shielded_instance_config` block, failing an org policy requiring Shielded VM with Secure Boot (`constraints/compute.requireShieldedVm`).

## Change

Added `shielded_instance_config` to both the `cloudscanner` and DSPM instance templates, with all three Shielded VM settings enabled explicitly:

```hcl
shielded_instance_config {
  enable_secure_boot          = var.enable_secure_boot   # default true
  enable_vtpm                 = true
  enable_integrity_monitoring = true
}
```

- vTPM and integrity monitoring are set explicitly (on) rather than relying on provider defaults, to fully satisfy policies that require a complete Shielded VM configuration.
- Secure Boot is gated behind a new `enable_secure_boot` variable (default `true`) so a customer on a non-UEFI custom `boot_image` can opt out.

## Validation

- **Constraint:** Secure Boot requires a `UEFI_COMPATIBLE`, signed boot image.
- **Current source image is fine:** default `ubuntu-os-cloud/ubuntu-2404-lts-amd64` (live: `ubuntu-2404-noble-amd64-v20260615`) carries the `UEFI_COMPATIBLE` guest OS feature and Ubuntu LTS images are signed for Secure Boot. No image change needed.
- Secure Boot blocks unsigned kernel modules; the scanner startup loads none, so no impact.
- `terraform fmt -check` and `terraform validate` pass.

## Also: CI fix (trivy)

The pinned `TRIVY_VERSION` `v0.63.0` was removed upstream (404 from the trivy releases), so the Security Scan job failed on every run. Bumped to `v0.71.2` (current latest).

## Rollout note

Applying replaces the instance templates and recreates the MIGs (`create_before_destroy` / `replace_triggered_by`), so scanner VMs will cycle on rollout — expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[UP-2441]: https://upwindsecurity.atlassian.net/browse/UP-2441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ