### PR TITLE
fix(UP-2569): use latest secret version for scaler, README updated

### DIFF
--- a/modules/main/README.md
+++ b/modules/main/README.md
@@ -18,15 +18,15 @@ The module creates:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.23.0, <= 6.35.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.23.0, < 8.0.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 6.35.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.4 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.23.0, < 8.0.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.0.0 |
 
 ## Modules
 
@@ -41,22 +41,17 @@ No modules.
 | [google_compute_firewall.cloudscanner_fw_iap_ssh](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
 | [google_compute_network.cloudscanner_network](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network) | resource |
 | [google_compute_region_instance_group_manager.cloudscanner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_group_manager) | resource |
+| [google_compute_region_instance_group_manager.cloudscanner_dspm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_group_manager) | resource |
+| [google_compute_region_instance_template.cloudscanner_dspm_inst_templates](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_template) | resource |
 | [google_compute_region_instance_template.cloudscanner_inst_templates](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_template) | resource |
 | [google_compute_router.cloudscanner_router](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router) | resource |
 | [google_compute_router_nat.cloudscanner_router_nat](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router_nat) | resource |
 | [google_compute_subnetwork.cloudscanner_subnetwork](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork) | resource |
-| [google_project_iam_member.cloudscanner_instance_template_mgmt_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.cloudscanner_instance_template_test_creation_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.cloudscanner_storage_delete_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.cloudscanner_snapshot_reader_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.cloudscanner_snapshot_writer_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [null_resource.always_run](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [google_compute_network.custom_network](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_network) | data source |
 | [google_compute_subnetwork.custom_subnet](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
 | [google_secret_manager_secret.scanner_client_id](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/secret_manager_secret) | data source |
 | [google_secret_manager_secret.scanner_client_secret](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/secret_manager_secret) | data source |
-| [google_secret_manager_secret_version.scanner_client_id_v1](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/secret_manager_secret_version) | data source |
-| [google_secret_manager_secret_version.scanner_client_secret_v1](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/secret_manager_secret_version) | data source |
 | [google_service_account.cloudscanner_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/service_account) | data source |
 | [google_service_account.cloudscanner_scaler_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/service_account) | data source |
 
@@ -64,23 +59,29 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_access_token"></a> [access\_token](#input\_access\_token) | The access token used to authenticate with Google Cloud. | `string` | | no |
+| <a name="input_access_token"></a> [access\_token](#input\_access\_token) | The access token used to authenticate with Google Cloud. | `string` | n/a | yes |
 | <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | The zones within the region that will be used for zone based resources. | `list(any)` | <pre>[<br/>  "us-central1-a",<br/>  "us-central1-b",<br/>  "us-central1-c"<br/>]</pre> | no |
-| <a name="input_boot_disk_size_gb"></a> [boot\_disk\_size\_gb](#input\_boot\_disk\_size\_gb) | The disk size in GB to use. | `number` | `20` | no |
+| <a name="input_boot_disk_size_gb"></a> [boot\_disk\_size\_gb](#input\_boot\_disk\_size\_gb) | The disk size in GB to use. | `number` | `40` | no |
 | <a name="input_boot_disk_type"></a> [boot\_disk\_type](#input\_boot\_disk\_type) | The disk type to use. | `string` | `"pd-standard"` | no |
 | <a name="input_boot_image"></a> [boot\_image](#input\_boot\_image) | The source image to use for instances. | `string` | `"ubuntu-os-cloud/ubuntu-2404-lts-amd64"` | no |
 | <a name="input_cloudscanner_sa_email"></a> [cloudscanner\_sa\_email](#input\_cloudscanner\_sa\_email) | The cloudscanner service account email to use. | `string` | n/a | yes |
 | <a name="input_cloudscanner_scaler_sa_email"></a> [cloudscanner\_scaler\_sa\_email](#input\_cloudscanner\_scaler\_sa\_email) | The cloudscanner scaler service account email to use. | `string` | n/a | yes |
 | <a name="input_custom_network"></a> [custom\_network](#input\_custom\_network) | The name of a custom network to use. | `string` | `""` | no |
 | <a name="input_custom_subnet"></a> [custom\_subnet](#input\_custom\_subnet) | The name of a custom subnetwork to use. | `string` | `""` | no |
+| <a name="input_default_labels"></a> [default\_labels](#input\_default\_labels) | Default labels applied to all resources (can be overridden) | `map(string)` | <pre>{<br/>  "component": "upwind",<br/>  "managed_by": "terraform"<br/>}</pre> | no |
+| <a name="input_default_scheduler_region"></a> [default\_scheduler\_region](#input\_default\_scheduler\_region) | The default region to use for the Cloud Scheduler job if no specific region is provided. | `string` | `"us-central1"` | no |
+| <a name="input_dspm_enabled"></a> [dspm\_enabled](#input\_dspm\_enabled) | Enable DSPM (Data Security Posture Management). If false, DSPM MIG will not be created. | `bool` | `false` | no |
 | <a name="input_enable_iap_ssh"></a> [enable\_iap\_ssh](#input\_enable\_iap\_ssh) | Whether to enable SSH access via IAP | `bool` | `true` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | A map of labels to apply to all resources | `map(string)` | `{}` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | The machine type to use. | `string` | `"e2-highmem-2"` | no |
 | <a name="input_min_nat_ports_per_vm"></a> [min\_nat\_ports\_per\_vm](#input\_min\_nat\_ports\_per\_vm) | Minimum number of ports allocated to each VM for NAT service | `number` | `64` | no |
 | <a name="input_public_uri_domain"></a> [public\_uri\_domain](#input\_public\_uri\_domain) | The public URI domain. | `string` | `"upwind.io"` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region that all resources will be created in. | `string` | `"us-central1"` | no |
 | <a name="input_scaler_function_schedule"></a> [scaler\_function\_schedule](#input\_scaler\_function\_schedule) | The schedule to use for the scaler function. | `string` | `"*/10 * * * *"` | no |
 | <a name="input_scanner_id"></a> [scanner\_id](#input\_scanner\_id) | The Upwind Scanner ID. | `string` | n/a | yes |
+| <a name="input_scheduler_region"></a> [scheduler\_region](#input\_scheduler\_region) | The region to use for the Cloud Scheduler job. If not set, the default\_scheduler\_region will be used. | `string` | `""` | no |
 | <a name="input_target_size"></a> [target\_size](#input\_target\_size) | The target size of the autoscaling group. | `number` | `1` | no |
+| <a name="input_upwind_infra_region"></a> [upwind\_infra\_region](#input\_upwind\_infra\_region) | The Upwind infrastructure region where the resources are created. | `string` | `"us"` | no |
 | <a name="input_upwind_orchestrator_project"></a> [upwind\_orchestrator\_project](#input\_upwind\_orchestrator\_project) | The main Google Cloud project where the resources are created. | `string` | n/a | yes |
 | <a name="input_upwind_organization_id"></a> [upwind\_organization\_id](#input\_upwind\_organization\_id) | The Upwind Organization ID. | `string` | n/a | yes |
 
@@ -89,4 +90,5 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_gcp_asg_name"></a> [gcp\_asg\_name](#output\_gcp\_asg\_name) | The name of the Cloud Scanner Instance Manager Group. |
+| <a name="output_gcp_dspm_asg_name"></a> [gcp\_dspm\_asg\_name](#output\_gcp\_dspm\_asg\_name) | The name of the Cloud Scanner DSPM Instance Manager Group. |
 <!-- END_TF_DOCS -->

--- a/modules/main/README.md
+++ b/modules/main/README.md
@@ -79,6 +79,7 @@ No modules.
 | <a name="input_region"></a> [region](#input\_region) | The region that all resources will be created in. | `string` | `"us-central1"` | no |
 | <a name="input_scaler_function_schedule"></a> [scaler\_function\_schedule](#input\_scaler\_function\_schedule) | The schedule to use for the scaler function. | `string` | `"*/10 * * * *"` | no |
 | <a name="input_scanner_id"></a> [scanner\_id](#input\_scanner\_id) | The Upwind Scanner ID. | `string` | n/a | yes |
+| <a name="input_scanner_secret_version"></a> [scanner\_secret\_version](#input\_scanner\_secret\_version) | Secret Manager version for the scanner client id/secret mounted into the scaler job. Defaults to "latest", so a rotated credential is picked up on the next job execution with no apply. Set to a specific numeric version (e.g. "3") only to deliberately pin. | `string` | `"latest"` | no |
 | <a name="input_scheduler_region"></a> [scheduler\_region](#input\_scheduler\_region) | The region to use for the Cloud Scheduler job. If not set, the default\_scheduler\_region will be used. | `string` | `""` | no |
 | <a name="input_target_size"></a> [target\_size](#input\_target\_size) | The target size of the autoscaling group. | `number` | `1` | no |
 | <a name="input_upwind_infra_region"></a> [upwind\_infra\_region](#input\_upwind\_infra\_region) | The Upwind infrastructure region where the resources are created. | `string` | `"us"` | no |

--- a/modules/main/main.tf
+++ b/modules/main/main.tf
@@ -540,8 +540,12 @@ resource "google_cloud_run_v2_job" "scaler_function" {
           name = "UPWIND_AUTH_CLIENT_ID"
           value_source {
             secret_key_ref {
-              secret  = data.google_secret_manager_secret.scanner_client_id.secret_id
-              version = data.google_secret_manager_secret_version.scanner_client_id_v1.version
+              secret = data.google_secret_manager_secret.scanner_client_id.secret_id
+              # "latest" is resolved at each job execution, so a rotated secret is
+              # picked up automatically without a terraform apply. Pinning a numeric
+              # version here would leave the scaler on a stale (possibly disabled)
+              # version after rotation, causing ObtainToken 401s.
+              version = "latest"
             }
           }
         }
@@ -551,7 +555,7 @@ resource "google_cloud_run_v2_job" "scaler_function" {
           value_source {
             secret_key_ref {
               secret  = data.google_secret_manager_secret.scanner_client_secret.secret_id
-              version = data.google_secret_manager_secret_version.scanner_client_secret_v1.version
+              version = "latest"
             }
           }
         }

--- a/modules/main/main.tf
+++ b/modules/main/main.tf
@@ -94,7 +94,7 @@ resource "google_compute_region_instance_template" "cloudscanner_inst_templates"
     
     # Get client ID with error checking
     echo "Attempting to retrieve UPWIND_CLIENT_ID..."
-    if ! CLIENT_ID_OUTPUT=$(timeout 30 gcloud secrets versions access latest --secret=${data.google_secret_manager_secret.scanner_client_id.secret_id} --project=${local.project} 2>&1); then
+    if ! CLIENT_ID_OUTPUT=$(timeout 30 gcloud secrets versions access ${var.scanner_secret_version} --secret=${data.google_secret_manager_secret.scanner_client_id.secret_id} --project=${local.project} 2>&1); then
       echo "ERROR: Failed to retrieve UPWIND_CLIENT_ID from Secret Manager"
       echo "Error output: $CLIENT_ID_OUTPUT"
       exit 1
@@ -109,7 +109,7 @@ resource "google_compute_region_instance_template" "cloudscanner_inst_templates"
     
     # Get client secret with error checking
     echo "Attempting to retrieve UPWIND_CLIENT_SECRET..."
-    if ! CLIENT_SECRET_OUTPUT=$(timeout 30 gcloud secrets versions access latest --secret=${data.google_secret_manager_secret.scanner_client_secret.secret_id} --project=${local.project} 2>&1); then
+    if ! CLIENT_SECRET_OUTPUT=$(timeout 30 gcloud secrets versions access ${var.scanner_secret_version} --secret=${data.google_secret_manager_secret.scanner_client_secret.secret_id} --project=${local.project} 2>&1); then
       echo "ERROR: Failed to retrieve UPWIND_CLIENT_SECRET from Secret Manager"
       echo "Error output: $CLIENT_SECRET_OUTPUT"
       exit 1
@@ -320,7 +320,7 @@ resource "google_compute_region_instance_template" "cloudscanner_dspm_inst_templ
     
     # Get client ID with error checking
     echo "Attempting to retrieve UPWIND_CLIENT_ID..."
-    if ! CLIENT_ID_OUTPUT=$(timeout 30 gcloud secrets versions access latest --secret=${data.google_secret_manager_secret.scanner_client_id.secret_id} --project=${local.project} 2>&1); then
+    if ! CLIENT_ID_OUTPUT=$(timeout 30 gcloud secrets versions access ${var.scanner_secret_version} --secret=${data.google_secret_manager_secret.scanner_client_id.secret_id} --project=${local.project} 2>&1); then
       echo "ERROR: Failed to retrieve UPWIND_CLIENT_ID from Secret Manager"
       echo "Error output: $CLIENT_ID_OUTPUT"
       exit 1
@@ -335,7 +335,7 @@ resource "google_compute_region_instance_template" "cloudscanner_dspm_inst_templ
     
     # Get client secret with error checking
     echo "Attempting to retrieve UPWIND_CLIENT_SECRET..."
-    if ! CLIENT_SECRET_OUTPUT=$(timeout 30 gcloud secrets versions access latest --secret=${data.google_secret_manager_secret.scanner_client_secret.secret_id} --project=${local.project} 2>&1); then
+    if ! CLIENT_SECRET_OUTPUT=$(timeout 30 gcloud secrets versions access ${var.scanner_secret_version} --secret=${data.google_secret_manager_secret.scanner_client_secret.secret_id} --project=${local.project} 2>&1); then
       echo "ERROR: Failed to retrieve UPWIND_CLIENT_SECRET from Secret Manager"
       echo "Error output: $CLIENT_SECRET_OUTPUT"
       exit 1
@@ -541,11 +541,11 @@ resource "google_cloud_run_v2_job" "scaler_function" {
           value_source {
             secret_key_ref {
               secret = data.google_secret_manager_secret.scanner_client_id.secret_id
-              # "latest" is resolved at each job execution, so a rotated secret is
-              # picked up automatically without a terraform apply. Pinning a numeric
-              # version here would leave the scaler on a stale (possibly disabled)
-              # version after rotation, causing ObtainToken 401s.
-              version = "latest"
+              # Defaults to "latest", which is resolved at each job execution, so a
+              # rotated credential is picked up automatically without a terraform apply.
+              # Pinning a numeric version here would leave the scaler on a stale
+              # (possibly disabled) version after rotation, causing ObtainToken 401s.
+              version = var.scanner_secret_version
             }
           }
         }
@@ -555,7 +555,7 @@ resource "google_cloud_run_v2_job" "scaler_function" {
           value_source {
             secret_key_ref {
               secret  = data.google_secret_manager_secret.scanner_client_secret.secret_id
-              version = "latest"
+              version = var.scanner_secret_version
             }
           }
         }

--- a/modules/main/secrets.tf
+++ b/modules/main/secrets.tf
@@ -7,13 +7,3 @@ data "google_secret_manager_secret" "scanner_client_secret" {
   project   = local.project
   secret_id = "upwind-scanner-client-secret-${local.resource_suffix_hyphen}"
 }
-
-data "google_secret_manager_secret_version" "scanner_client_id_v1" {
-  project = local.project
-  secret  = data.google_secret_manager_secret.scanner_client_id.secret_id
-}
-
-data "google_secret_manager_secret_version" "scanner_client_secret_v1" {
-  project = local.project
-  secret  = data.google_secret_manager_secret.scanner_client_secret.secret_id
-}

--- a/modules/main/variables.tf
+++ b/modules/main/variables.tf
@@ -20,6 +20,17 @@ variable "scanner_id" {
   }
 }
 
+variable "scanner_secret_version" {
+  type        = string
+  description = "Secret Manager version for the scanner client id/secret mounted into the scaler job. Defaults to \"latest\", so a rotated credential is picked up on the next job execution with no apply. Set to a specific numeric version (e.g. \"3\") only to deliberately pin."
+  default     = "latest"
+
+  validation {
+    condition     = var.scanner_secret_version == "latest" || can(regex("^[1-9][0-9]*$", var.scanner_secret_version))
+    error_message = "The scanner_secret_version must be \"latest\" or a positive integer version number (e.g. \"3\")."
+  }
+}
+
 variable "public_uri_domain" {
   type        = string
   description = "The public URI domain."


### PR DESCRIPTION
Version was being pinned to whatever 'latest' was at plan time. This meant that a rotated secret was never picked up - therefore the scaler failed to authenticate.

Instead use `latest` explicitly. This should pick up any rotated secret in GCP.