### PR TITLE
feat(AG-0): Allow ap for upwind_infra_region

### DIFF
--- a/modules/main/variables.tf
+++ b/modules/main/variables.tf
@@ -43,8 +43,8 @@ variable "upwind_infra_region" {
   default     = "us"
 
   validation {
-    condition     = can(regex("^(us|eu|me|pdc01)$", var.upwind_infra_region))
-    error_message = "The Upwind infrastructure region must be one of 'us', 'eu', or 'me'"
+    condition     = can(regex("^(us|eu|me|pdc01|ap)$", var.upwind_infra_region))
+    error_message = "The Upwind infrastructure region must be one of 'us', 'eu', 'me' or 'ap'"
   }
 }
 


### PR DESCRIPTION
Fixes onboarding for cloudscanners in the AP region

```terraform
│ Error: Invalid value for variable
│ 
│   on main.tf line 93, in module "google_cloudscanner_ucsc-7ea959c2f9c33343":
│   93:   upwind_infra_region = var.upwind_infra_region
│     ├────────────────
│     │ var.upwind_infra_region is "ap"
```