### PR TITLE
fix(UP-5412): scaler vpc egress default value

### DIFF
--- a/.config/.releaserc.json
+++ b/.config/.releaserc.json
@@ -138,6 +138,13 @@
       }
     ],
     [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md"],
+        "message": "chore(release): v${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    [
       "@semantic-release/github",
       {
         "assets": [

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,7 @@ on:
       - main
 
 permissions:
-  contents: write        # Required to create and push release tags
-  pull-requests: write   # Required to create PRs for version updates
-  issues: write          # Required to create and manage labels on PRs
+  contents: write        # Required to create and push release tags and the changelog commit
 
 jobs:
   discover-modules:
@@ -51,27 +49,10 @@ jobs:
         # Extra plugins and presets (need explicit installation):
         extra_plugins: |
           @semantic-release/changelog@6.0.3
+          @semantic-release/git@10.0.1
           conventional-changelog-conventionalcommits@9.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Create Pull Request with Changelog
-      if: success() && steps.release.outputs.new_release_published == 'true'
-      uses: peter-evans/create-pull-request@v7
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: "chore(release): v${{ steps.release.outputs.new_release_version }} [skip ci]"
-        title: "chore(release): v${{ steps.release.outputs.new_release_version }}"
-        body: |
-          This PR contains the release changes for v${{ steps.release.outputs.new_release_version }}, including:
-          - Updated CHANGELOG.md
-          - Release tag: v${{ steps.release.outputs.new_release_version }}
-
-          This PR was automatically created by the release workflow.
-        branch: release-${{ steps.release.outputs.new_release_version }}
-        labels: |
-          kind/release
-          lifecycle/automated
 
     - name: Build Terraform Modules
       if: steps.release.outputs.new_release_published == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.8.0](https://github.com/upwindsecurity/terraform-google-cloudscanner/compare/v1.7.2...v1.8.0) (2026-08-13)
+
+### Features
+
+* **UP-5412:** add vpc_access to cloud run job definition ([#55](https://github.com/upwindsecurity/terraform-google-cloudscanner/issues/55)) ([607382c](https://github.com/upwindsecurity/terraform-google-cloudscanner/commit/607382c50aa73cb1e5293a734ba164bba499e80c))
+
+## [1.7.2](https://github.com/upwindsecurity/terraform-google-cloudscanner/compare/v1.7.1...v1.7.2) (2026-06-30)
+
+### Bug Fixes
+
+* **UP-2569:** use latest secret version for scaler, README updated ([#50](https://github.com/upwindsecurity/terraform-google-cloudscanner/issues/50)) ([1e060e7](https://github.com/upwindsecurity/terraform-google-cloudscanner/commit/1e060e7294d894747d5cc430717adbb604db5a73))
+
+## [1.7.1](https://github.com/upwindsecurity/terraform-google-cloudscanner/compare/v1.7.0...v1.7.1) (2026-06-30)
+
+### Bug Fixes
+
+* **UP-2641:** Add AP Region ([#51](https://github.com/upwindsecurity/terraform-google-cloudscanner/issues/51)) ([c59fa52](https://github.com/upwindsecurity/terraform-google-cloudscanner/commit/c59fa529945e49a5ae0dc585739f47f5f4774980))
+
+## [1.7.0](https://github.com/upwindsecurity/terraform-google-cloudscanner/compare/v1.6.3...v1.7.0) (2026-06-19)
+
+### Features
+
+* **UP-2441:** enable recommended ShieldedVM settings on instance templates ([#48](https://github.com/upwindsecurity/terraform-google-cloudscanner/issues/48)) ([3aa0778](https://github.com/upwindsecurity/terraform-google-cloudscanner/commit/3aa0778e0030febfb1a06ed1d5186e3d2b8bb6ca))
+
 ## [1.6.3](https://github.com/upwindsecurity/terraform-google-cloudscanner/compare/v1.6.2...v1.6.3) (2026-06-09)
 
 ### Bug Fixes

--- a/modules/main/variables.tf
+++ b/modules/main/variables.tf
@@ -51,7 +51,7 @@ variable "scaler_function_schedule" {
 variable "scaler_vpc_egress" {
   type        = string
   description = "Egress setting for the scaler function's Direct VPC egress. Some customer GCP org policies (constraints/run.allowedVPCEgress) require Cloud Run resources to declare this explicitly."
-  default     = "PRIVATE_RANGES_ONLY"
+  default     = "ALL_TRAFFIC"
 
   validation {
     condition     = contains(["ALL_TRAFFIC", "PRIVATE_RANGES_ONLY"], var.scaler_vpc_egress)


### PR DESCRIPTION
Change the default value to `ALL_TRAFFIC` - we are dependent on a working VPC anyway, and this is the more restrictive setting (all traffic routes through VPC).